### PR TITLE
Add four provisional color palettes for the UI

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="tealAccent">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="" href="" />

--- a/admin/src/index.css
+++ b/admin/src/index.css
@@ -1,98 +1,105 @@
 @plugin "daisyui";
 @import "tailwindcss";
 
-/*:root {*/
-/*    --color-forest-green-50: oklch(95.3% 0.03546 154.36);*/
-/*    --color-forest-green-100: oklch(93.019% 0.05379 152.61);*/
-/*    --color-forest-green-200: oklch(88.496% 0.09295 150.09);*/
-/*    --color-forest-green-300: oklch(84.195% 0.133 147.89);*/
-/*    --color-forest-green-400: oklch(80.183% 0.173 145.7);*/
-/*    --color-forest-green-500: oklch(76.576% 0.20816 143.96);*/
-/*    --color-forest-green-600: oklch(72.02% 0.22168 142.84);*/
-/*    --color-forest-green-700: oklch(63.04% 0.19031 142.35);*/
-/*    --color-forest-green-800: oklch(50.154% 0.14648 141.69);*/
-/*    --color-forest-green-900: oklch(36.287% 0.10002 140.99);*/
-/*    --color-forest-green-950: oklch(28.668% 0.07447 140.26);*/
-/*}*/
-
-/*:root {*/
-/*    --color-christi: oklch(68.899% 0.21829 140.26);*/
-/*    --color-christi-50: oklch(99.766% 0.00445 134.85);*/
-/*    --color-christi-100: oklch(97.757% 0.03066 137.82);*/
-/*    --color-christi-200: oklch(94.245% 0.08308 138.22);*/
-/*    --color-christi-300: oklch(91.032% 0.13515 138.19);*/
-/*    --color-christi-400: oklch(87.965% 0.18087 138.49);*/
-/*    --color-christi-500: oklch(85.509% 0.22158 138.91);*/
-/*    --color-christi-600: oklch(83.514% 0.25009 139.6);*/
-/*    --color-christi-700: oklch(79.186% 0.25216 140.32);*/
-/*    --color-christi-800: oklch(68.899% 0.21829 140.26);*/
-/*    --color-christi-900: oklch(54.167% 0.16927 140.08);*/
-/*    --color-christi-950: oklch(46.717% 0.14477 139.92);*/
-/*}*/
-
-/* tus variables OKLCH definidas primero (globales) */
 :root {
-    --color-christi-50: oklch(99.766% 0.00445 134.85);
-    --color-christi-100: oklch(97.757% 0.03066 137.82);
-    --color-christi-200: oklch(94.245% 0.08308 138.22);
-    --color-christi-300: oklch(91.032% 0.13515 138.19);
-    --color-christi-400: oklch(87.965% 0.18087 138.49);
-    --color-christi-500: oklch(85.509% 0.22158 138.91);
-    --color-christi-600: oklch(83.514% 0.25009 139.6);
-    --color-christi-700: oklch(79.186% 0.25216 140.32);
-    --color-christi-800: oklch(68.899% 0.21829 140.26);
-    --color-christi-900: oklch(54.167% 0.16927 140.08);
-    --color-christi-950: oklch(46.717% 0.14477 139.92);
+    --color-vectra-green-50:  oklch(97% 0.02 160);
+    --color-vectra-green-100: oklch(94% 0.03 160);
+    --color-vectra-green-200: oklch(88% 0.05 155);
+    --color-vectra-green-300: oklch(78% 0.07 150);
+    --color-vectra-green-400: oklch(70% 0.09 150);
+    --color-vectra-green-500: oklch(60% 0.10 150);
+    --color-vectra-green-600: oklch(52% 0.11 150);
+    --color-vectra-green-700: oklch(45% 0.10 150);
+    --color-vectra-green-800: oklch(38% 0.09 150);
+    --color-vectra-green-900: oklch(30% 0.08 150);
 }
 
-/* importa daisyui y el plugin de temas */
-@plugin "daisyui";
 @plugin "daisyui/theme" {
-    name: "vectraChristi";
-    default: true;        /* hace que este tema sea el default al compilar */
-    prefersdark: false;   /* si quieres que sea dark por defecto pon true */
+    name: "vectraModern";
+    default: false;
     color-scheme: light;
 
-    /* aquí enlazamos los roles de DaisyUI con tus variables OKLCH */
-    --color-base-100: var(--color-christi-50);
-    --color-base-200: var(--color-christi-100);
-    --color-base-300: var(--color-christi-200);
-    --color-base-content: var(--color-christi-950);
+    --color-base-100: oklch(98% 0.01 120);
+    --color-base-200: oklch(94% 0.02 120);
+    --color-base-300: oklch(90% 0.03 120);
+    --color-base-content: oklch(25% 0.05 120);
 
-    --color-primary: var(--color-christi-700);
+    --color-primary: var(--color-vectra-green-500);
     --color-primary-content: #ffffff;
+    --color-secondary: var(--color-vectra-green-700);
+    --color-accent: var(--color-vectra-green-300);
+    --color-neutral: oklch(20% 0.02 120);
+    --color-neutral-content: oklch(95% 0.02 120);
 
-    --color-secondary: var(--color-christi-500);
-    --color-secondary-content: #ffffff;
-
-    --color-accent: var(--color-christi-300);
-    --color-accent-content: var(--color-christi-950);
-
-    --color-neutral: var(--color-christi-900);
-    --color-neutral-content: var(--color-christi-100);
-
-    --color-info: oklch(75% 0.18 220);
-    --color-info-content: #ffffff;
-
-    --color-success: var(--color-christi-600);
-    --color-success-content: #ffffff;
-
-    --color-warning: oklch(85% 0.18 85);
-    --color-warning-content: #111827;
-
-    --color-error: oklch(60% 0.19 25);
-    --color-error-content: #ffffff;
-
-    /* border radius / sizes (opcional, copia ejemplo doc) */
-    --radius-selector: 1rem;
-    --radius-field: 0.25rem;
-    --radius-box: 0.5rem;
-
-    --size-selector: 0.25rem;
-    --size-field: 0.25rem;
-
-    --border: 1px;
-
-    --depth: 1;
-    --noise: 0;
+    --color-info: oklch(70% 0.10 250);
+    --color-success: var(--color-vectra-green-600);
+    --color-warning: oklch(80% 0.15 90);
+    --color-error: oklch(60% 0.20 25);
 }
+
+@plugin "daisyui/theme" {
+    name: "verdantCalm";
+    default: false;
+    color-scheme: light;
+
+    --color-base-100: oklch(98% 0.01 90);
+    --color-base-200: oklch(95% 0.02 90);
+    --color-base-300: oklch(92% 0.03 90);
+    --color-base-content: oklch(20% 0.02 90);
+
+    --color-primary: oklch(55% 0.08 220);
+    --color-primary-content: #ffffff;
+    --color-secondary: oklch(60% 0.10 140);
+    --color-accent: oklch(75% 0.12 140);
+    --color-neutral: oklch(50% 0.02 90);
+    --color-neutral-content: oklch(95% 0.01 90);
+
+    --color-success: oklch(60% 0.10 140);
+    --color-warning: oklch(85% 0.15 80);
+    --color-error: oklch(60% 0.18 30);
+}
+
+@plugin "daisyui/theme" {
+    name: "tealAccent";
+    default: true;
+    color-scheme: light;
+
+    --color-base-100: #f8f5f2;
+    --color-base-200: #f0ede9;
+    --color-base-300: #e6e3df;
+    --color-base-content: #232323;
+
+    --color-primary: #078080;
+    --color-primary-content: #232323;
+    --color-secondary: #f45d48;
+    --color-accent: #f8f5f2;
+    --color-neutral: #222525;
+    --color-neutral-content: #f8f5f2;
+
+    --color-success: #078080;
+    --color-warning: #f4a261;
+    --color-error: #e45858;
+}
+
+@plugin "daisyui/theme" {
+    name: "indigoAccent";
+    default: false;
+    color-scheme: light;
+
+    --color-base-100: #fffffe;
+    --color-base-200: #f8f8fa;
+    --color-base-300: #f0f0f3;
+    --color-base-content: #2b2c34;
+
+    --color-primary: #6246ea;
+    --color-primary-content: #fffffe;
+    --color-secondary: #d1d1e9;
+    --color-accent: #e45858;
+    --color-neutral: #2b2c34;
+    --color-neutral-content: #fffffe;
+
+    --color-success: #078080;
+    --color-warning: #f4a261;
+    --color-error: #e45858;
+}
+

--- a/admin/src/index.css
+++ b/admin/src/index.css
@@ -1,3 +1,98 @@
 @plugin "daisyui";
 @import "tailwindcss";
 
+/*:root {*/
+/*    --color-forest-green-50: oklch(95.3% 0.03546 154.36);*/
+/*    --color-forest-green-100: oklch(93.019% 0.05379 152.61);*/
+/*    --color-forest-green-200: oklch(88.496% 0.09295 150.09);*/
+/*    --color-forest-green-300: oklch(84.195% 0.133 147.89);*/
+/*    --color-forest-green-400: oklch(80.183% 0.173 145.7);*/
+/*    --color-forest-green-500: oklch(76.576% 0.20816 143.96);*/
+/*    --color-forest-green-600: oklch(72.02% 0.22168 142.84);*/
+/*    --color-forest-green-700: oklch(63.04% 0.19031 142.35);*/
+/*    --color-forest-green-800: oklch(50.154% 0.14648 141.69);*/
+/*    --color-forest-green-900: oklch(36.287% 0.10002 140.99);*/
+/*    --color-forest-green-950: oklch(28.668% 0.07447 140.26);*/
+/*}*/
+
+/*:root {*/
+/*    --color-christi: oklch(68.899% 0.21829 140.26);*/
+/*    --color-christi-50: oklch(99.766% 0.00445 134.85);*/
+/*    --color-christi-100: oklch(97.757% 0.03066 137.82);*/
+/*    --color-christi-200: oklch(94.245% 0.08308 138.22);*/
+/*    --color-christi-300: oklch(91.032% 0.13515 138.19);*/
+/*    --color-christi-400: oklch(87.965% 0.18087 138.49);*/
+/*    --color-christi-500: oklch(85.509% 0.22158 138.91);*/
+/*    --color-christi-600: oklch(83.514% 0.25009 139.6);*/
+/*    --color-christi-700: oklch(79.186% 0.25216 140.32);*/
+/*    --color-christi-800: oklch(68.899% 0.21829 140.26);*/
+/*    --color-christi-900: oklch(54.167% 0.16927 140.08);*/
+/*    --color-christi-950: oklch(46.717% 0.14477 139.92);*/
+/*}*/
+
+/* tus variables OKLCH definidas primero (globales) */
+:root {
+    --color-christi-50: oklch(99.766% 0.00445 134.85);
+    --color-christi-100: oklch(97.757% 0.03066 137.82);
+    --color-christi-200: oklch(94.245% 0.08308 138.22);
+    --color-christi-300: oklch(91.032% 0.13515 138.19);
+    --color-christi-400: oklch(87.965% 0.18087 138.49);
+    --color-christi-500: oklch(85.509% 0.22158 138.91);
+    --color-christi-600: oklch(83.514% 0.25009 139.6);
+    --color-christi-700: oklch(79.186% 0.25216 140.32);
+    --color-christi-800: oklch(68.899% 0.21829 140.26);
+    --color-christi-900: oklch(54.167% 0.16927 140.08);
+    --color-christi-950: oklch(46.717% 0.14477 139.92);
+}
+
+/* importa daisyui y el plugin de temas */
+@plugin "daisyui";
+@plugin "daisyui/theme" {
+    name: "vectraChristi";
+    default: true;        /* hace que este tema sea el default al compilar */
+    prefersdark: false;   /* si quieres que sea dark por defecto pon true */
+    color-scheme: light;
+
+    /* aquí enlazamos los roles de DaisyUI con tus variables OKLCH */
+    --color-base-100: var(--color-christi-50);
+    --color-base-200: var(--color-christi-100);
+    --color-base-300: var(--color-christi-200);
+    --color-base-content: var(--color-christi-950);
+
+    --color-primary: var(--color-christi-700);
+    --color-primary-content: #ffffff;
+
+    --color-secondary: var(--color-christi-500);
+    --color-secondary-content: #ffffff;
+
+    --color-accent: var(--color-christi-300);
+    --color-accent-content: var(--color-christi-950);
+
+    --color-neutral: var(--color-christi-900);
+    --color-neutral-content: var(--color-christi-100);
+
+    --color-info: oklch(75% 0.18 220);
+    --color-info-content: #ffffff;
+
+    --color-success: var(--color-christi-600);
+    --color-success-content: #ffffff;
+
+    --color-warning: oklch(85% 0.18 85);
+    --color-warning-content: #111827;
+
+    --color-error: oklch(60% 0.19 25);
+    --color-error-content: #ffffff;
+
+    /* border radius / sizes (opcional, copia ejemplo doc) */
+    --radius-selector: 1rem;
+    --radius-field: 0.25rem;
+    --radius-box: 0.5rem;
+
+    --size-selector: 0.25rem;
+    --size-field: 0.25rem;
+
+    --border: 1px;
+
+    --depth: 1;
+    --noise: 0;
+}

--- a/admin/tailwind.config.js
+++ b/admin/tailwind.config.js
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+
+module.exports = {
+    content: [
+        "./index.html",
+        "./src/**/*.{js,ts,jsx,tsx}"
+    ],
+    theme: {
+        extend: {},
+    },
+    plugins: [
+        require("daisyui"),
+    ]
+}


### PR DESCRIPTION
This PR introduces four new color palettes for the application interface:

- vectraModern
- verdantCalm
- tealAccent (default)
- indigoAccent

These palettes are provisional and may be refined based.

They allow for experimenting with different color schemes in the UI using Tailwind + DaisyUI.
