### PR TITLE
Restore original Short and Long descriptions for the develop command

### DIFF
--- a/cmd/develop.go
+++ b/cmd/develop.go
@@ -14,13 +14,14 @@ import (
 
 var developCmd = &cobra.Command{
 	Use:   "develop",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: "Run VectraG in development mode",
+	Long: `The develop command starts VectraG with development-friendly settings and tools, allowing you to:
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+- Create, update, and delete content models
+- Experiment with schema changes safely
+- Iterate quickly during local development
+
+This mode is intended for local environments and early-stage development.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		basePort := 51987
 		host := "localhost"


### PR DESCRIPTION
This PR restores the original Short and Long descriptions for the `develop` command
in the CLI.

No functional changes are included; this is purely a documentation fix.
